### PR TITLE
[ci skip] Use after_initialize instead of to_prepare in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ class SignUpNotifier
 end
 
 # config/initializers/newspaper.rb
-Rails.configuration.to_prepare do
+Rails.configuration.after_initialize do
   Newspaper.subscribe(:user_create, SignUpNotifier.new)
 end
 


### PR DESCRIPTION
`to_prepare` may run twice. `after_initialize` is only once.

https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots